### PR TITLE
bench: use GOAMD64=v3, increase benchmark count, interleave runs

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -1,7 +1,35 @@
 #!/bin/bash
+set -euo pipefail
 
+# We run each benchmark 20 times total (10x2) for 0.5 sec each, with some interleaving of the benchmarks.
+benchloops=10
+benchcount=2
+benchtime=0.5s
+
+# Ask to use more modern CPU instructions on amd64.
+goarch=$(go env GOARCH)
+if [[ "$goarch" == "amd64" ]]; then
+  export GOAMD64=v3
+  echo GOAMD64="$GOAMD64"
+fi
+
+# Execute the interleaved benchmarks, with swiss.Map first.
 go test -c
-./swiss.test -test.v -test.run - -test.bench . -test.count 10 -test.benchmem -test.timeout 10h | tee out
-grep -v swissMap out | sed 's,/runtimeMap,,g' > out.runtime
-grep -v runtimeMap out | sed 's,/swissMap,,g' > out.swiss
-benchstat out.runtime out.swiss
+echo "Available benchmarks:"
+go test -list=^Bench
+rm -f out
+for i in $(seq $benchloops); do
+  for impl in swissMap runtimeMap; do
+    # Manually get the list of benchmarks.
+    # The next line can be edited to control the order of results, such as 'for benchmark in MapPutGrow MapGetHit; do'
+    for benchmark in $(go test -list=^Bench | grep '^Bench'); do
+      ./swiss.test -test.v -test.run=NONE -test.bench="$benchmark"/impl="$impl" -test.count="$benchcount" \
+        -test.benchtime="$benchtime" -test.benchmem -test.timeout=10h 2>&1 | tee -a out
+    done
+  done
+done
+
+# Compare the results.
+grep -v swissMap out | egrep -v '^Benchmark[^ ]+$' | sed 's,/impl=runtimeMap,,g' > out.runtime
+grep -v runtimeMap out | egrep -v '^Benchmark[^ ]+$' | sed 's,/impl=swissMap,,g' > out.swiss
+benchstat out.runtime out.swiss 2>&1 | tee out.benchstat


### PR DESCRIPTION
An individual benchmark run can be "unlucky" in terms of how many overflow buckets there are for the runtime map, or how skewed the occupancy is for groups in swiss.Map, and so on.

To help with noise and hopefully make it easier to compare results across different commits, we update bench.sh to do 20 runs per benchmark rather than 10, but reduce the time per benchmark from 1 second to 0.5 seconds to keep the total time roughly the same. More samples also gives more grist to the statistical mill for benchstat to identify outliers, and of course halves the impact of each sample.

We also interleave the swiss.Map and runtime map runs. This can help reduce the impact of background processes, or "noisy neighbors" in a public cloud environment, etc. We run swiss.Map first given it is usually the more interesting data (e.g., in case someone wants to spot check initial results or ^C early, etc.).

As a follow up to #29, we also set GOAMD64 or GOARM environment variables based on the platform to help use more modern CPU instructions.

While we are here, we also fix the munging of the results to account for the new benchmark name format that was introduced in #22.